### PR TITLE
Exclude lock and node_modules from docker build and remove frontend .env from tracking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
+**/node_modules
+node_modules
+
+# Bug in NPM that fails build when using lock
+**/bun.lockb
+**/package-lock.json
+
 .venv
-.node-modules
 build
 dist

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /dist
 
 # local env files
+.env
 .env.local
 .env.*.local
 


### PR DESCRIPTION
* NPM is failing on docker build when bun.lockb or node_modules is
  copied to the container