### PR TITLE
backend: modem: at: Change fetch IMEI impl

### DIFF
--- a/backend/modem/at.py
+++ b/backend/modem/at.py
@@ -215,7 +215,10 @@ class ATCommander:
         return await self.command(ATCommand.IMEI_SN, ATDivider.EQ, '0')
 
     async def get_imei(self) -> ATResponse:
-        return await self.command(ATCommand.IMEI_SN, ATDivider.EQ, '1')
+        try:
+            return await self.command(ATCommand.IMEI_SN, cmd_id_response=False)
+        except SerialSafeReadFailed:
+            return await self.command(ATCommand.IMEI_SN, ATDivider.EQ, '1')
 
     async def get_international_mobile_subscriber_id(self) -> ATResponse:
         return await self.command(ATCommand.IMSI, cmd_id_response=False)


### PR DESCRIPTION
* Change to use by default AT+CGSN instead of AT+CGSN=1 as provided in manual since some modems does not implement it, and only use AT+CGSN=1 to fallback