### PR TITLE
backend: modem: lte-base: Add edge cases for SN

### DIFF
--- a/backend/modem/adapters/quectel/base.py
+++ b/backend/modem/adapters/quectel/base.py
@@ -65,18 +65,33 @@ class QuectelLTEBase(Modem):
         # OK
         response = (await cmd.get_mt_info()).data[0]
         firmware = (await cmd.get_firmware_version_details()).data[0]
-        imei = (await cmd.get_imei()).data[0]
-        serial_number = (await cmd.get_serial_number()).data[0]
-        imsi = (await cmd.get_international_mobile_subscriber_id()).data[0]
+
+        imei = None
+        try:
+            imei = (await cmd.get_imei()).data[0][0]
+        except Exception:
+            pass
+
+        serial_number = None
+        try:
+            serial_number = (await cmd.get_serial_number()).data[0][0]
+        except Exception:
+            pass
+
+        imsi = None
+        try:
+            imsi = (await cmd.get_international_mobile_subscriber_id()).data[0][0]
+        except Exception:
+            pass
 
         return ModemDeviceDetails(
             device=self.device,
             id=self.id,
             manufacturer=response[0],
             product=response[1],
-            imei=imei[0],
-            imsi=imsi[0],
-            serial_number=serial_number[0],
+            imei=imei,
+            imsi=imsi,
+            serial_number=serial_number,
             firmware_revision=ModemFirmwareRevision(
                 firmware_revision=firmware[0].replace("VERSION: ", ""),
                 timestamp=firmware[1],

--- a/backend/modem/models.py
+++ b/backend/modem/models.py
@@ -19,10 +19,10 @@ class ModemFirmwareRevision(BaseModel):
 
 
 class ModemDeviceDetails(ModemDevice):
-    imei: str
-    serial_number: str
-    imsi: Optional[str] = None
     firmware_revision: ModemFirmwareRevision
+    imei: Optional[str] = None
+    serial_number: Optional[str] = None
+    imsi: Optional[str] = None
 
 
 class ModemClockDetails(BaseModel):


### PR DESCRIPTION
* As some older LTE-EG25-G modems  with firmware from 2019 does not respond the IMEI/SN query, we add a bypass for these values