### PR TITLE
Update base front name for Cellular Modem Manager

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -10,7 +10,7 @@ from fastapi_versioning import VersionedFastAPI
 from api.v1.routers import blueos_router_v1, cells_router_v1, index_router_v1, modem_router_v1
 
 application = FastAPI(
-    title="Cellphone Modem Manager Configuration API",
+    title="Cellular Modem Manager Configuration API",
     description="This extension API provides ways to configure and explore resources of cellphone modems",
 )
 
@@ -25,7 +25,7 @@ application = VersionedFastAPI(application, prefix_format="/v{major}.{minor}", e
 @application.get("/", status_code=200)
 async def root() -> RedirectResponse:
     """
-    Root endpoint for Cellphone Modem Manager extension.
+    Root endpoint for Cellular Modem Manager extension.
     """
 
     return RedirectResponse(url="/static/index.html")

--- a/backend/api/static/service.json
+++ b/backend/api/static/service.json
@@ -1,6 +1,6 @@
 {
-    "name":"Modem Manager",
-    "description":"Simple extension for managing cellphone modems",
+    "name":"Cellular Modem Manager",
+    "description":"Simple extension for managing Cellular Modems",
     "icon":"mdi-signal-variant",
     "company":"Blue Robotics",
     "version":"0.1.0",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cellphone Modem Manager</title>
+    <title>Cellular Modem Manager</title>
 </head>
 
 <body>


### PR DESCRIPTION
As per request of the support team, was decided that unifying name to "Cellular Modem Manager"  on the parts where user see the extension.